### PR TITLE
Rename HDMI_BYPASS to HDMI_IN_BYPASS to match name of input on player

### DIFF
--- a/oppoudpsdk/command/enums.py
+++ b/oppoudpsdk/command/enums.py
@@ -111,7 +111,7 @@ class SetInputSource(enum.Enum):
   OPTICAL_IN = "3"
   COAX_IN = "4"
   USB_IN = "5"
-  HDMI_BYPASS = "6"
+  HDMI_IN_BYPASS = "6"
 
   def __str__(self):
     return str(self.value)

--- a/oppoudpsdk/response/enums.py
+++ b/oppoudpsdk/response/enums.py
@@ -147,7 +147,7 @@ class InputSource(enum.Enum):
   OPTICAL_IN = "3"
   COAX_IN = "4"
   USB_IN = "5"
-  HDMI_BYPASS = "6"
+  HDMI_IN_BYPASS = "6"
 
   def __str__(self):
     return str(self.name.replace("_"," ").title())


### PR DESCRIPTION
Rename HDMI_BYPASS to HDMI_IN_BYPASS to match name of input on player.